### PR TITLE
Lua multithread fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(${TARGET}_Sources
         "${CMAKE_CURRENT_SOURCE_DIR}/src/ltm.c"
         #${CMAKE_CURRENT_SOURCE_DIR}/"src/lua.c"
         #${CMAKE_CURRENT_SOURCE_DIR}/"src/luac.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/luauser.c"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/lundump.c"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/lutf8lib.c"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/lvm.c"

--- a/include/lua.h
+++ b/include/lua.h
@@ -513,5 +513,7 @@ struct lua_Debug {
 * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ******************************************************************************/
 
+void LuaLock(lua_State* L);
+void LuaUnlock(lua_State* L);
 
 #endif

--- a/include/luaconf.h
+++ b/include/luaconf.h
@@ -753,9 +753,8 @@
 ** without modifying the main part of the file.
 */
 
-
-
-
+#define lua_lock(L) LuaLock(L)
+#define lua_unlock(L) LuaUnlock(L)
 
 #endif
 

--- a/src/luauser.c
+++ b/src/luauser.c
@@ -1,0 +1,40 @@
+#include <windows.h>
+#include "lua.h"
+
+static struct {
+    CRITICAL_SECTION LockSct;
+    BOOL Init;
+} Gl;
+
+void LuaLockInitial(lua_State* L)
+{
+    if (!Gl.Init)
+    {
+        /* Create a mutex */
+        InitializeCriticalSection(&Gl.LockSct);
+        Gl.Init = TRUE;
+    }
+}
+
+void LuaLockFinal(lua_State* L) /* Not called by Lua. */
+{
+    /* Destroy a mutex. */
+    if (Gl.Init)
+    {
+        DeleteCriticalSection(&Gl.LockSct);
+        Gl.Init = FALSE;
+    }
+}
+
+void LuaLock(lua_State* L)
+{
+    LuaLockInitial(L);
+    /* Wait for control of mutex */
+    EnterCriticalSection(&Gl.LockSct);
+}
+
+void LuaUnlock(lua_State* L)
+{
+    /* Release control of mutex */
+    LeaveCriticalSection(&Gl.LockSct);
+}


### PR DESCRIPTION
Add stability to Lua by implementing lua_lock and lua_unlock. This allows threads to call into Lua safely.