### PR TITLE
More multithreaded fixes for Lua.

### DIFF
--- a/include/lua.h
+++ b/include/lua.h
@@ -516,5 +516,7 @@ struct lua_Debug {
 
 void LuaLock(lua_State* L);
 void LuaUnlock(lua_State* L);
+void LuaLockInitial(lua_State* L);
+void LuaLockFinal(lua_State* L);
 
 #endif

--- a/include/luaconf.h
+++ b/include/luaconf.h
@@ -780,6 +780,8 @@
 
 #define lua_lock(L) LuaLock(L)
 #define lua_unlock(L) LuaUnlock(L)
-
+#define luai_userstateopen(L) LuaLockInitial(L)
+#define luai_userstateclose(L) LuaLockFinal(L)
+#define luai_userstatethread(L,L1) LuaLockInitial(L1)
 #endif
 

--- a/src/luauser.c
+++ b/src/luauser.c
@@ -16,7 +16,7 @@ void LuaLockInitial(lua_State* L)
     }
 }
 
-void LuaLockFinal(lua_State* L) /* Not called by Lua. */
+void LuaLockFinal(lua_State* L)
 {
     /* Destroy a mutex. */
     if (Gl.Init)


### PR DESCRIPTION
Fixed: If lua_close is called, it didn't properly invalidate the mutex. This causes mods to hang when they are reloaded in UE4SS.
I tested this with Returnal, where I reloaded mods and noticed that ExecuteWithDelay and other asynchronous actions no longer worked.